### PR TITLE
Fix order reference month format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+[Unreleased]
+
+### Fixes
+- Fixed an issue where `now()->year` would return an int on single digit months, but we need to have a leading zero.
+
 ## [2.0-beta3] - 2021-12-24
 ### Fixes
 - Fixed and issue where the meilisearch set up wasn't creating the indexes it needed if they didn't exist.

--- a/src/Base/OrderReferenceGenerator.php
+++ b/src/Base/OrderReferenceGenerator.php
@@ -27,7 +27,7 @@ class OrderReferenceGenerator implements OrderReferenceGeneratorInterface
 
         $year = $order->created_at->year;
 
-        $month = $order->created_at->month;
+        $month = $order->created_at->format('m');
 
         $latest = Order::select(
                 DB::RAW('MAX(reference) as reference')


### PR DESCRIPTION
Given it's the first month, when using `now()->year` it returns `1` but we want `01` so this PR should fix that by using the date format method.